### PR TITLE
klippy: Drop support for python2

### DIFF
--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -8,13 +8,13 @@ are as follows:
 
 Klipper uses a C module to handle some kinematics calculations more quickly.
 This module needs to be compiled at packaging time to avoid introducing a
-runtime dependency on a compiler. To compile the C module, run `python2
+runtime dependency on a compiler. To compile the C module, run `python3
 klippy/chelper/__init__.py`.
 
 ## Compiling python code
 
 Many distributions have a policy of compiling all python code before packaging
-to improve startup time. You can do this by running `python2 -m compileall
+to improve startup time. You can do this by running `python3 -m compileall
 klippy`.
 
 ## Versioning
@@ -22,7 +22,7 @@ klippy`.
 If you are building a package of Klipper from git, it is usual practice not to
 ship a .git directory, so the versioning must be handled without git.  To do
 this, use the script shipped in `scripts/make_version.py` which should be run as
-follows: `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
+follows: `python3 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
 
 ## Sample packaging script
 

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Main code for host side printer firmware
 #
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -91,22 +91,6 @@ def dump_mcu_build():
 
 
 ######################################################################
-# Python2 wrapper hacks
-######################################################################
-
-def setup_python2_wrappers():
-    if sys.version_info.major >= 3:
-        return
-    # Add module hacks so that common Python3 module imports work in Python2
-    import ConfigParser, Queue, io, StringIO, time
-    sys.modules["configparser"] = ConfigParser
-    sys.modules["queue"] = Queue
-    io.StringIO = StringIO.StringIO
-    time.process_time = time.clock
-setup_python2_wrappers()
-
-
-######################################################################
 # General system and software information
 ######################################################################
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -10,7 +10,6 @@ BUILD_DIR=${PWD}/ci_build
 export PATH=${BUILD_DIR}/pru-gcc/bin:${PATH}
 export PATH=${BUILD_DIR}/or1k-linux-musl-cross/bin:${PATH}
 PYTHON=${BUILD_DIR}/python-env/bin/python
-PYTHON2=${BUILD_DIR}/python2-env/bin/python
 
 
 ######################################################################
@@ -69,14 +68,6 @@ start_test klippy "Test klippy import (Python3)"
 $PYTHON klippy/klippy.py --import-test
 finish_test klippy "Test klippy import (Python3)"
 
-start_test klippy "Test klippy import (Python2)"
-$PYTHON2 klippy/klippy.py --import-test
-finish_test klippy "Test klippy import (Python2)"
-
 start_test klippy "Test invoke klippy (Python3)"
 $PYTHON scripts/test_klippy.py -d ${DICTDIR} test/klippy/*.test
 finish_test klippy "Test invoke klippy (Python3)"
-
-start_test klippy "Test invoke klippy (Python2)"
-$PYTHON2 scripts/test_klippy.py -d ${DICTDIR} test/klippy/*.test
-finish_test klippy "Test invoke klippy (Python2)"

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -16,7 +16,7 @@ mkdir -p ${BUILD_DIR} ${CACHE_DIR}
 ######################################################################
 
 echo -e "\n\n=============== Install system dependencies\n\n"
-PKGS="virtualenv python2-dev libffi-dev build-essential"
+PKGS="virtualenv libffi-dev build-essential"
 PKGS="${PKGS} gcc-avr avr-libc"
 PKGS="${PKGS} libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi"
 PKGS="${PKGS} pv libmpfr-dev libgmp-dev libmpc-dev texinfo bison flex"
@@ -70,13 +70,3 @@ echo -e "\n\n=============== Install python3 virtualenv\n\n"
 cd ${MAIN_DIR}
 virtualenv -p python3 ${BUILD_DIR}/python-env
 ${BUILD_DIR}/python-env/bin/pip install -r ${MAIN_DIR}/scripts/klippy-requirements.txt
-
-
-######################################################################
-# Create python2 virtualenv environment
-######################################################################
-
-echo -e "\n\n=============== Install python2 virtualenv\n\n"
-cd ${MAIN_DIR}
-virtualenv -p python2 ${BUILD_DIR}/python2-env
-${BUILD_DIR}/python2-env/bin/pip install -r ${MAIN_DIR}/scripts/klippy-requirements.txt


### PR DESCRIPTION
It's infeasible at this point to ask people to test their code on Python 2, so just drop support for it.

---

This PR doesn't completely remove all uses of Python 2. Those will have to be done manually. But that's cleanup.