### PR TITLE
config: Use tmctrigorilla driver for the Kobra Plus

### DIFF
--- a/KLIPPER_DIFF.md
+++ b/KLIPPER_DIFF.md
@@ -16,8 +16,10 @@ introduce a `tmctrigorilla` configuration section, allowing configuring stepper
 drivers for these boards. This allows us to support any printer controlled by
 such a board.
 
-As part of this, we added a config file for the Anycubic Kobra. While in theory,
-we could also support the Kobra Max and Kobra Plus, someone would have to
+As part of this, we added a config file for the Anycubic Kobra.
+We have also ported the mainline Klipper configs for the Kobra Plus to use the
+tmctrigorilla configuration.
+While in theory we could also support the Kobra Max, someone would have to
 contribute a tested config.
 
 ## Implementation changes

--- a/config/printer-anycubic-kobra-plus-2022.cfg
+++ b/config/printer-anycubic-kobra-plus-2022.cfg
@@ -1,25 +1,11 @@
-# This file contains a configuration for the Anycubic Kobra Plus printer.
-#
-# The Kobra Plus mainboard must be modified to correct conflicting UART
-# addresses. As delivered, the X stepper and E0 stepper use UART address 0.
-# To correct, move resistor R65 to R66. This moves the X stepper to address 3.
-#
-# After making this modification, any future firmwares will need to use the new
-# address for the X stepper. To revert to the stock firmware, either undo the
-# modification, or recompile the stock firmware using the correct addresses for
-# X_SLAVE_ADDRESS and E0_SLAVE_ADDRESS.
-#
-# See docs/Config_Reference.md for a description of parameters.
-#
-# To build the firmware, use the following configuration:
-#   - Micro-controller: Huada Semiconductor HC32F460
-#   - Communication interface: Serial (PA3 & PA2) - Anycube
-#
-# Installation:
-#  1. Rename the klipper bin to `firmware.bin` and copy it to an SD Card.
-#  2. Power off the Printer, insert the SD Card and power it on.
-#  3. The printer should beep several times and the LCD will be stuck on the
-#     Splash screen.
+# This file contains pin mappings for the stock Anycubic Kobra Plus (Trigorilla V1.0.4)
+# To use this config, during "make menuconfig" select the HC32F460 architecture
+# and communication interface to serial on PA3 and PA2.
+
+# Note that the "make flash" command does not work with this board.
+# After running "make", rename the out/klipper.bin file to out/firmware.bin
+# Copy the file out/firmware.bin to an SD card formatted to FAT32, with an
+# MBR partition table. Then restart the printer with the SD card inserted.
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
@@ -44,12 +30,12 @@ position_endstop: -4
 position_max: 304
 homing_speed: 100
 
-[tmc2209 stepper_x]
+[tmctrigorilla stepper_x]
 uart_pin: PA15
 tx_pin: PA9
 sense_resistor: 0.100
-run_current: 0.9
-uart_address: 3
+run_current: 0.8
+uart_address: 0
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -120,14 +106,6 @@ pid_ki: 1.08
 pid_kd: 119.0
 min_temp: 0
 max_temp: 275
-
-[tmc2208 extruder]
-uart_pin: PA15
-tx_pin: PA9
-sense_resistor: 0.100
-run_current: 0.8
-uart_address: 0
-stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: PA0


### PR DESCRIPTION
**This is untested. Should work though.**

I had to lower the X stepper current to avoid overloading the extruder.

Porting a Trigorilla board to use our workaround is easy:

- Ensure the tmc2209 stepper_x and extruder sections are identical
- Ensure the stepper_x and extruder microsteps are identical
- Set the tmc2209 stepper_x section to use the tmctrigorilla driver
- Remove the tmc2209 extruder section

Make sure to test the configuration!