### PR TITLE
compiler: Make barrier() a memory barrier

### DIFF
--- a/klippy/chelper/compiler.h
+++ b/klippy/chelper/compiler.h
@@ -2,7 +2,7 @@
 #define __COMPILER_H
 // Low level definitions for C languange and gcc compiler.
 
-#define barrier() __asm__ __volatile__("": : :"memory")
+#define barrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)

--- a/lib/can2040/can2040.c
+++ b/lib/can2040/can2040.c
@@ -28,7 +28,7 @@
 #endif
 
 // Helper compiler definitions
-#define barrier() __asm__ __volatile__("": : :"memory")
+#define barrier() __asm__ __volatile__("dmb": : :"memory")
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -2,7 +2,7 @@
 #define __COMPILER_H
 // Low level definitions for C languange and gcc compiler.
 
-#define barrier() __asm__ __volatile__("": : :"memory")
+#define barrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)


### PR DESCRIPTION
A lot of code written using barrier() assumes it is a memory barrier, when in fact it is a compiler barrier. Make it a memory barrier.